### PR TITLE
Stop instrumentation after exit

### DIFF
--- a/src/agent/agent.cc
+++ b/src/agent/agent.cc
@@ -351,6 +351,7 @@ namespace sp {
           (void*)g_parser->GetFuncAddrFromName("wrapper_exit");
       assert(wrapper_exit);
       g_context->SetWrapperExit(wrapper_exit);
+    }
 
     // Register Events for initial instrumentation
     init_event_->RegisterEvent();

--- a/src/agent/agent.cc
+++ b/src/agent/agent.cc
@@ -35,6 +35,7 @@
 #include "agent/agent.h"
 #include "agent/context.h"
 #include "agent/patchapi/addr_space.h"
+#include "agent/patchapi/object.h"
 #include "common/utils.h"
 #include "common/common.h"
 #include "injector/injector.h"
@@ -71,7 +72,7 @@ namespace sp {
     }
 	
    char error_file[255],output_file[255];
-     snprintf(error_file,255,"./tmp/spi/spi-error-%d", getpid());
+     snprintf(error_file,255,"%s/%s/tmp/spi/spi-error-%d", getenv("SP_DIR"), getenv("PLATFORM"), getpid());
      g_error_fp=fopen(error_file , "a+");
      if (g_error_fp == NULL) {
         std::cerr << "Failed to open file for output erro info: " << strerror(errno) << std::endl;
@@ -79,7 +80,7 @@ namespace sp {
         g_error_fp = stderr;
       }
 
-     snprintf(output_file,255,"./tmp/spi/spi-output-%d", getpid());
+     snprintf(output_file,255,"%s/%s/tmp/spi/spi-output-%d", getenv("SP_DIR"), getenv("PLATFORM"), getpid());
      g_output_fp=fopen(output_file , "a+");
      if (g_output_fp == NULL) {
         std::cerr << "Failed to open file for output stdout info: " << strerror(errno) << std::endl;
@@ -90,7 +91,7 @@ namespace sp {
     // Enalbe outputing debug info to /tmp/spi-$PID
     if (getenv("SP_FDEBUG")) {
       char fn[255];
-      snprintf(fn, 255, "./tmp/spi/spi-%d", getpid());
+      snprintf(fn, 255, "%s/%s/tmp/spi/spi-%d", getenv("SP_DIR"), getenv("PLATFORM"), getpid());
       g_debug_fp = fopen(fn, "a+");
       if (g_debug_fp == NULL) {
         std::cerr << "Failed to open file for output debug info: " << strerror(errno) << std::endl;
@@ -350,12 +351,45 @@ namespace sp {
           (void*)g_parser->GetFuncAddrFromName("wrapper_exit");
       assert(wrapper_exit);
       g_context->SetWrapperExit(wrapper_exit);
-    }
-    // Register Events
+
+    // Register Events for initial instrumentation
     init_event_->RegisterEvent();
     sp_debug("init registered");
     fini_event_->RegisterEvent();
     sp_debug("fini registered");
+
+    std::string exit_function_payload_str("toggle_off_instrumentation_entry");
+    void* exit_function_payload = (void*)g_parser->GetFuncAddrFromName(exit_function_payload_str);
+
+    if (exit_function_payload == NULL) {
+      sp_perror("Failed to find exit function payload to toggle off instrumentation, return immediately");
+      return;
+    }
+
+    // Instrument exit function inside libc to stop SPI when exit is called
+    FuncSet found_exit_funcs;
+    std::string exit_string("__GI_exit");
+    for (ph::AddrSpace::ObjMap::iterator ci = g_as->objMap().begin();
+       ci != g_as->objMap().end(); ci++) {
+      SpObject* obj = OBJ_CAST(ci->second);
+      if (obj->name().find("libc.so") != string::npos) {
+        g_parser->GetFuncsByName(obj, exit_string, false, &found_exit_funcs);
+      }
+    }
+    for (FuncSet::iterator i = found_exit_funcs.begin();
+        i != found_exit_funcs.end(); i++) {
+      if (*i == NULL) continue;
+      SpFunction* f = *i;
+      sp_debug("Pre-instrumenting exit function: %s", f->name().c_str());
+      g_context->init_propeller()->go(f,
+                                      exit_function_payload,
+                                      g_context->init_exit());
+    }
+
+    // a sleep interval to attach gdb
+    if (getenv("SP_GDBSLEEP")) {
+      sleep(15);
+    }
   }
 
 }

--- a/src/agent/parser.h
+++ b/src/agent/parser.h
@@ -118,6 +118,11 @@ namespace sp {
     AGENT_EXPORT dt::Address
         GetFuncAddrFromName(string func_name_without_path);
 
+    bool GetFuncsByName(sp::SpObject* obj,
+                        std::string name,
+                        bool mangled,
+                        sp::FuncSet* func_set);
+
     // Dump instructions from a buffer
     AGENT_EXPORT string
         DumpInsns(void* addr,
@@ -169,10 +174,6 @@ namespace sp {
 
     ph::PatchMgrPtr CreateMgr(PatchObjects& patch_objs);
 
-    bool GetFuncsByName(sp::SpObject* obj,
-                        std::string name,
-                        bool mangled,
-                        sp::FuncSet* func_set);
     bool FindPltFunc(sp::SpObject* obj,
                         std::string name,
                         bool mangled,
@@ -183,7 +184,7 @@ namespace sp {
         sp::FuncSet* func_set);
 
     //Get the load address of the symbol from AddressTranslat::createAddressTranslator
-   // dt::Address getLoadAddress(sb::Symtab* sym);
+    // dt::Address getLoadAddress(sb::Symtab* sym);
 
   };
 

--- a/src/agent/propeller.cc
+++ b/src/agent/propeller.cc
@@ -66,25 +66,28 @@ namespace sp {
                   PayloadFunc exit,
                   SpPoint* point,
                   StringSet* inst_calls) {
-    assert(func);
+    if (func == NULL) {
+      sp_debug("FATAL: func is NULL");
+      return false;
+    }
 
     sp_debug("START PROPELLING - propel to callees of function %s",
              func->name().c_str());
    
-    if(func->name().find("std::")!=std::string::npos) {
-	sp_debug("TODO: libstdc++ functions: stop propelling");
-	return true;
+    if (func->name().find("std::")!=std::string::npos || func->name().find("cxx")!=std::string::npos) {
+      sp_debug("TODO: libstdc++ functions: stop propelling");
+      return true;
+    }
+
+    if (strcmp(func->name().c_str(), "exit") == 0) {
+      sp_debug("exit function, stop propelling");
+      return true;
     }
     // 1. Find points according to type
     Points pts;
     ph::PatchMgrPtr mgr = g_parser->mgr();
     assert(mgr);
-    ph::PatchFunction* cur_func = NULL;
-    if (point) {
-      cur_func = func;
-    } else {
-      cur_func = g_parser->FindFunction(func->GetMangledName());
-    }
+    ph::PatchFunction* cur_func = func;
 
     if (!cur_func) return false;
 

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -76,7 +76,6 @@ extern FILE* g_error_fp;
 */
 #define sp_print(...) do { \
   if (getenv("SP_FDEBUG")) {  \
-    char* nodir = basename((char*)__FILE__);  \
     fprintf(g_output_fp, __VA_ARGS__);  \
     fprintf(g_output_fp, "\n");  \
   } else {  \

--- a/src/injector/injector.cc
+++ b/src/injector/injector.cc
@@ -60,10 +60,6 @@ SpInjector::ptr SpInjector::Create(dt::PID pid) {
 
 //////////////////////////////////////////////////////////////////////
 SpInjector::SpInjector(dt::PID pid) : pid_(pid) {
-
-  FILE *fp = fopen("./tmp/proc_control_debug", "w");
-  pc::setDebugChannel(fp);
-  pc::setDebug(true);
   proc_ = Process::attachProcess(pid);
   if (proc_ == Process::ptr()) {
     sp_debug("Injector [pid = %5d] - Failed to attach to process %d.", getpid(),


### PR DESCRIPTION
To stop the instrumentation after the libc exit function is called. To solve this, we specifically instrument the "__GI_exit" function in libc.so object. In the special payload entry function for this instrumentation point, the global IN_INSTRUMENTATION flag is toggled off.

Fixes github issue #11 