### PR TITLE
Smarter memory allocation

### DIFF
--- a/src/agent/patchapi/addr_space-x86_64.cc
+++ b/src/agent/patchapi/addr_space-x86_64.cc
@@ -155,13 +155,13 @@ SpAddrSpace::UpdateFreeIntervals() {
   
   // Re-arrange free buffers. Some rules:
   // - Reduce each "hole" between two mapped objects to less than 1.5GB
-  // - Each interval should have size smaller than 128MB
+  // - Each interval should have size smaller than 16MB
 
   FreeIntervalList tmp_list;
   std::copy(free_intervals_.begin(), free_intervals_.end(),
             back_inserter(tmp_list));
   free_intervals_.clear();
-  const size_t max_interval_size = (const size_t)1024*1024*128;
+  const size_t max_interval_size = (const size_t)1024*1024*16;
   const size_t max_mapped_area_size = (const size_t)1024*1024*(1024+512);
   for (FreeIntervalList::iterator fi = tmp_list.begin();
        fi != tmp_list.end(); fi++) {

--- a/src/agent/patchapi/addr_space.h
+++ b/src/agent/patchapi/addr_space.h
@@ -87,6 +87,8 @@ namespace sp {
                              int perm);
 
     void InitMemoryAllocator();
+    bool allocateNewInterval(SpObject* obj);
+
     protected:
 
     MemMappings mem_maps_;

--- a/src/agent/patchapi/object-x86_64.cc
+++ b/src/agent/patchapi/object-x86_64.cc
@@ -73,7 +73,7 @@ namespace sp {
 		}
 
 		small_freebufs_.base =base;
-		small_freebufs_. buf_size = size ;
+		small_freebufs_.buf_size = size ;
 
 	}
 
@@ -91,11 +91,13 @@ namespace sp {
 			g_as->allocateNewInterval(this);
 		}
 
-		if(small_freebufs_.buf_size >=size) {
-			ret = small_freebufs_.base +size ;
+		if (small_freebufs_.buf_size >= size) {
+			ret = small_freebufs_.base;
 			//sp_debug("Number of free buffers: %d", small_freebufs_.list.size());
 			sp_debug("%s: Returning %lu buffer at %lx", name().c_str(), size, ret);
-			small_freebufs_.base +=size + 1;		  
+			small_freebufs_.base += (size+1);
+			small_freebufs_.buf_size -= (size+1);
+			sp_debug("%s: %lu bytes left", name().c_str(), small_freebufs_.buf_size);
 			return ret;
 		}
 		size_t ps = getpagesize();

--- a/src/agent/patchapi/object.h
+++ b/src/agent/patchapi/object.h
@@ -35,6 +35,7 @@
 #include "common/common.h"
 
 #include "PatchObject.h"
+#include "agent/patchapi/addr_space.h"
 
 
 namespace sp {


### PR DESCRIPTION
This is a work around for better memory allocation in SPI. It allocates a chunk of 16MB memory for each code object. If a code object runs out of memory, a new chunk of memory is allocated for it.

Work around fix for #8 