### PR TITLE
Fix payload exit to get function call information

### DIFF
--- a/src/agent/agent.cc
+++ b/src/agent/agent.cc
@@ -341,17 +341,17 @@ namespace sp {
       // SpIpcMgr will be deleted in the destructor of SpContext
       g_context->SetIpcMgr(new SpIpcMgr());
     }
-    if (allow_ipc_ || allow_multithread_ || handle_dlopen_) {
-      sp_debug("ALLOW IPC OR MULTITHREADED OR HANDLE_DLOPEN");
-      void* wrapper_entry =
-          (void*)g_parser->GetFuncAddrFromName("wrapper_entry");
-      assert(wrapper_entry);
-      g_context->SetWrapperEntry(wrapper_entry);
-      void* wrapper_exit =
-          (void*)g_parser->GetFuncAddrFromName("wrapper_exit");
-      assert(wrapper_exit);
-      g_context->SetWrapperExit(wrapper_exit);
-    }
+
+    // Always use wrapper functions for payload entry and exit
+    sp_debug("ALLOW IPC OR MULTITHREADED OR HANDLE_DLOPEN");
+    void* wrapper_entry =
+        (void*)g_parser->GetFuncAddrFromName("wrapper_entry");
+    assert(wrapper_entry);
+    g_context->SetWrapperEntry(wrapper_entry);
+    void* wrapper_exit =
+        (void*)g_parser->GetFuncAddrFromName("wrapper_exit");
+    assert(wrapper_exit);
+    g_context->SetWrapperExit(wrapper_exit);
 
     // Register Events for initial instrumentation
     init_event_->RegisterEvent();

--- a/src/agent/context.h
+++ b/src/agent/context.h
@@ -48,6 +48,7 @@
 
 #include "frame.h"
 #include "walker.h"
+#include <stack>
 
 namespace sp {
 
@@ -102,12 +103,15 @@ class SpContext {
     char* FindExitInstAddrFromCallSitePoint(SpPoint*);
    
     //Table to store the non-instrumented functions and their return address
-   typedef std::map<SpPoint*,char*> PointRetAddrMap;
-   typedef std::map<dt::Address, SpPoint*> RetAddrCallPointMap;
-   PointRetAddrMap pt_ra_map_;
-   RetAddrCallPointMap ra_csp_map_;
+    typedef std::map<SpPoint*,char*> PointRetAddrMap;
+    typedef std::map<dt::Address, SpPoint*> RetAddrCallPointMap;
+    PointRetAddrMap pt_ra_map_;
+    RetAddrCallPointMap ra_csp_map_;
 
-   dt::Address GetReturnAddress();
+    dt::Address GetReturnAddress();
+
+    void PushPointCallInfo(PointCallInfo*);
+    PointCallInfo* PopPointCallInfo();
 
   protected:
 

--- a/src/agent/event.cc
+++ b/src/agent/event.cc
@@ -111,13 +111,13 @@ namespace sp {
        at the call stack size. If the call stack size is zero then
        the agent is preloaded. If the call stack size is greater 
        than zero, then the agent is injected */
-      FuncSet call_stack;
-      g_context->GetCallStack(&call_stack);
-      sp_debug("CALLSTACK - %lu calls in the call stack",
-               (unsigned long)call_stack.size());
+    FuncSet call_stack;
+    g_context->GetCallStack(&call_stack);
+    sp_debug("CALLSTACK - %lu calls in the call stack",
+              (unsigned long)call_stack.size());
 
-      if (call_stack.size()<=0)  {
-      sp_debug("PRELOAD - preload agent.so, and instrument main()");
+    if (call_stack.size() <= 0)  {
+    sp_debug("PRELOAD - preload agent.so, and instrument main()");
 
       SpFunction* f = g_parser->FindFunction("main");
       if (f) {
@@ -146,11 +146,11 @@ namespace sp {
         if (f->name().compare("main") == 0) {
           break;
         }
-	if (IsRecvLikeFunction(f->name())) { //.compare("recv") == 0) {
-		sp_debug("Recv like function on the stack");
-		//Modify the PC to start at a new location 
-	        g_context->init_propeller()->ModifyPC(f,g_context->init_exit());	
-	}
+        if (IsRecvLikeFunction(f->name())) {
+          sp_debug("Recv like function on the stack");
+          //Modify the PC to start at a new location 
+          g_context->init_propeller()->ModifyPC(f,g_context->init_exit());	
+        }
       } // Iterate through all the functions int the Call stack
     } // Injection mode
  
@@ -180,7 +180,7 @@ namespace sp {
       }
     }
 
-    for (FuncSet::iterator i = funcs_.begin(); 
+    for (FuncSet::iterator i = funcs_.begin();
            i != funcs_.end(); i++) {
         SpFunction* f = *i;
         sp_debug("PRE-INST FUNC - %s", f->name().c_str());

--- a/src/agent/inst_workers/trap_worker_impl.cc
+++ b/src/agent/inst_workers/trap_worker_impl.cc
@@ -67,6 +67,7 @@ bool TrapWorker::run(SpPoint* pt) {
   // This mapping is used in trap handler
   assert(pt->snip());
   inst_map_[call_addr] = pt->snip();
+  sp_debug("snippet added to instrumentation map at %xl", call_addr);
 
   // Install
   return install(pt);
@@ -183,6 +184,7 @@ void TrapWorker::OnTrap(int sig, siginfo_t* info, void* c) {
   assert(pc);
   InstMap& inst_map = TrapWorker::inst_map_;
   if (inst_map.find(pc) == inst_map.end()) {
+    sp_debug("instrumentation map for %lx not found", pc);
     dt::Address ret = g_context->GetReturnAddress();
 
     if (ret != (dt::Address)0) {
@@ -219,6 +221,8 @@ void TrapWorker::OnTrap(int sig, siginfo_t* info, void* c) {
 
       // Set pc to jump to the exit point instrumentation
       SpSnippet::set_pc((dt::Address)exit_snip_addr, c);
+    } else {
+      sp_debug("ret 0 inside trap handler");
     }
   } else {
     // Get patch area's address

--- a/src/agent/ipc/ipc_mgr.cc
+++ b/src/agent/ipc/ipc_mgr.cc
@@ -419,9 +419,7 @@ SpIpcMgr::BeforeEntry(SpPoint* pt) {
 
 // Will be called before user-specified exit-payload function.
 bool
-SpIpcMgr::BeforeExit(SpPoint* pt) {
-
- ph::PatchFunction* f = sp::Callee(pt);
+SpIpcMgr::BeforeExit(SpPoint* pt, SpFunction* f) {
   if (!f) return false;
 
   // fcntl F_SETOWN socket descriptors returned, so that it can receive OOB packets

--- a/src/agent/ipc/ipc_mgr.h
+++ b/src/agent/ipc/ipc_mgr.h
@@ -113,7 +113,7 @@ namespace sp {
     static bool BeforeEntry(SpPoint*);
 
     // Will be called before user-specified exit-payload function.
-    static bool BeforeExit(SpPoint*);
+    static bool BeforeExit(SpPoint*, SpFunction*);
 
     // Get workers
     SpPipeWorker* pipe_worker() const { return pipe_worker_; }

--- a/src/agent/ipc/ipc_workers/pipe_worker_impl.cc
+++ b/src/agent/ipc/ipc_workers/pipe_worker_impl.cc
@@ -124,7 +124,7 @@ SpPipeWorker::Inject(SpChannel* c,
   if (c->remote_pid > 0) {
 
     sp_debug("Remote pid is %d",c->remote_pid);
-    if(ProcessHasLibrary(c->remote_pid, "libmyagent")){
+    if(ProcessHasLibrary(c->remote_pid, "libagent")){
      sp_debug("Process %d already has agent shared library", c->remote_pid);
      return true;
     }


### PR DESCRIPTION
- Use wrapper functions for payload entry and payload exit functions
- Change payload exit function's parameter
- Allow user to return a void pointer in payload entry function, and retrieve it in payload exit function